### PR TITLE
Fix the bug when use MC

### DIFF
--- a/PyQSOFit.py
+++ b/PyQSOFit.py
@@ -859,7 +859,7 @@ class QSOFit():
             all_para[:, tra] = conti_fit.params
             all_L[:, tra] = np.asarray(self._L_conti(x, conti_fit.params))
             
-            if self.Fe_flux_range:
+            if self.Fe_flux_range is not None:
                 Fe_flux_result, Fe_flux_type, Fe_flux_name = self.Get_Fe_flux(self.Fe_flux_range, conti_fit.params[:6])
                 all_Fe_flux[:, tra] = Fe_flux_result
         

--- a/example/example.ipynb
+++ b/example/example.ipynb
@@ -482,7 +482,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Writing temp_job.py\n"
+      "Overwriting temp_job.py\n"
      ]
     }
    ],


### PR DESCRIPTION
Change `if self.Fe_flux_range:` to `if self.Fe_flux_range is not None:` in line 862.
According to Google Python Style Guide 2.14 which suggest “implicit” false, I mistakenly use `if self.Fe_flux_range:` in line 862, however,  different from a pure list, numpy array does not support such syntax any more.