### PR TITLE
fix duplicate axis

### DIFF
--- a/pyqsofit/PyQSOFit.py
+++ b/pyqsofit/PyQSOFit.py
@@ -1955,7 +1955,7 @@ class QSOFit():
                 format_name = plain_name[:insert_idx] + '\,' + plain_name[insert_idx:]
             else:
                 format_name = plain_name
-            return plain_name #rf'$\mathrm{{{format_name}}}$'
+            return rf'$\mathrm{{{format_name}}}$'
 
         pp = list(self.conti_fit.params.valuesdict().values())
 


### PR DESCRIPTION
This problem happens sometime after the late of last year (my collegues also had the same problem at a similar time point). I am guessing some package update issues (I am testing under the latest matplotlib 3.8.3). plt.subplots will create empty axis as a pre-set, this will overlap with the new subplot of the whole spectrum, as shown by the figure. Turn off the axis of the first row before making the new subplot will solve the problem.

Another point is at the end of the plot_fig func, I am a spyder user, the plot does not pop up in my window without plt.show(). And I found it is werid to put plt.close(fig) under if self.save_fig == True, so moved it out.

![Screenshot 2024-02-27 at 16 29 03](https://github.com/legolason/PyQSOFit/assets/49220392/144311f6-cc43-489a-b332-74017b651d79)
